### PR TITLE
press-contact page: Removed reference to core trac in Bugs section. 

### DIFF
--- a/pages/press-contact.html
+++ b/pages/press-contact.html
@@ -68,7 +68,7 @@
 <div id="bugs">
 	<h3>Found a bug?</h3>
 
-	<p>For reporting bugs in libraries, documentation, or content, the project's GitHub issues tracker should be used, except in the case of jQuery Core and jQuery UI, which track issues at <a href="http://bugs.jquery.com">http://bugs.jquery.com</a> and <a href="http://bugs.jqueryui.com">http://bugs.jqueryui.com</a>, respectively. The rest of the jQuery Foundation projects can be found at <a href="http://github.com/jquery">http://github.com/jquery</a></p>
+	<p>For reporting bugs in libraries, documentation, or content, the project's GitHub issues tracker should be used, except in the case of jQuery UI, which tracks issues at <a href="http://bugs.jqueryui.com">http://bugs.jqueryui.com</a>. The rest of the jQuery Foundation projects can be found at <a href="http://github.com/jquery">http://github.com/jquery</a></p>
 
 	<p>Still haven't found what you're looking for? Please feel free to contact:</p>
 


### PR DESCRIPTION
Fixes #16 

Removes the reference to core's trac bug tracker.

related to jquery/contribute.jquery.org#90
